### PR TITLE
feat: support array wildcard in outputEvents for tool call capture

### DIFF
--- a/src/headless-output-parser.ts
+++ b/src/headless-output-parser.ts
@@ -199,15 +199,19 @@ export const createOutputParser = (config: HeadlessAdapterConfig) => {
         for (const item of matchValue) {
           // Check if this array item matches the expected value
           if (mapping.match.value === '*') {
+            // Wildcard: match any non-null item
             if (item !== undefined && item !== null) {
               updates.push(createUpdate(item, mapping))
             }
-          } else if (item === mapping.match.value || (typeof item === 'object' && item !== null)) {
-            // For objects, check if they contain the match value
+          } else if (typeof item === 'object' && item !== null && 'type' in item) {
+            // For objects with 'type' property, check nested match
             const itemType = (item as Record<string, unknown>).type
             if (itemType === mapping.match.value) {
               updates.push(createUpdate(item, mapping))
             }
+          } else if (item === mapping.match.value) {
+            // For primitives, direct match
+            updates.push(createUpdate(item, mapping))
           }
         }
         if (updates.length > 0) {

--- a/src/headless-session-manager.ts
+++ b/src/headless-session-manager.ts
@@ -349,7 +349,7 @@ const collectOutput = async (
 
           // Parse as update first (so updates are emitted even for result lines)
           const update = parser.parseLine(line)
-          if (update) {
+          if (update !== null) {
             // Handle both single updates and arrays of updates (from wildcard matches)
             const updatesToProcess = Array.isArray(update) ? update : [update]
 

--- a/src/tests/headless.spec.ts
+++ b/src/tests/headless.spec.ts
@@ -330,6 +330,149 @@ describe('createOutputParser', () => {
     })
   })
 
+  describe('parseLine with array wildcards', () => {
+    const wildcardConfig = parseHeadlessConfig({
+      version: 1,
+      name: 'wildcard-test',
+      command: ['test'],
+      sessionMode: 'stream',
+      prompt: { flag: '-p' },
+      output: { flag: '--output', value: 'json' },
+      outputEvents: [
+        {
+          match: { path: '$.message.content[*].type', value: 'tool_use' },
+          emitAs: 'tool_call',
+          extract: { title: '$.name', status: "'pending'" },
+        },
+        {
+          match: { path: '$.items[*]', value: '*' },
+          emitAs: 'message',
+          extract: { content: '$.text' },
+        },
+      ],
+      result: {
+        matchPath: '$.type',
+        matchValue: 'result',
+        contentPath: '$.output',
+      },
+    })
+    const wildcardParser = createOutputParser(wildcardConfig)
+
+    test('returns array of updates for matching array items', () => {
+      const line = JSON.stringify({
+        message: {
+          content: [
+            { type: 'tool_use', name: 'Read', input: {} },
+            { type: 'text', value: 'Hello' },
+            { type: 'tool_use', name: 'Write', input: {} },
+          ],
+        },
+      })
+      const result = wildcardParser.parseLine(line)
+      expect(Array.isArray(result)).toBe(true)
+      if (Array.isArray(result)) {
+        expect(result).toHaveLength(2)
+        expect(result[0]!.type).toBe('tool_call')
+        expect(result[0]!.title).toBe('Read')
+        expect(result[0]!.status).toBe('pending')
+        expect(result[1]!.type).toBe('tool_call')
+        expect(result[1]!.title).toBe('Write')
+        expect(result[1]!.status).toBe('pending')
+      }
+    })
+
+    test('handles empty array gracefully', () => {
+      const line = JSON.stringify({
+        message: { content: [] },
+      })
+      const result = wildcardParser.parseLine(line)
+      expect(result).toBeNull()
+    })
+
+    test('handles non-matching array items', () => {
+      const line = JSON.stringify({
+        message: {
+          content: [
+            { type: 'text', value: 'No tool use here' },
+            { type: 'image', data: 'base64...' },
+          ],
+        },
+      })
+      const result = wildcardParser.parseLine(line)
+      expect(result).toBeNull()
+    })
+
+    test('matches wildcard value for all non-null items', () => {
+      const line = JSON.stringify({
+        items: [{ text: 'Item 1' }, { text: 'Item 2' }, { text: 'Item 3' }],
+      })
+      const result = wildcardParser.parseLine(line)
+      expect(Array.isArray(result)).toBe(true)
+      if (Array.isArray(result)) {
+        expect(result).toHaveLength(3)
+        expect(result[0]!.content).toBe('Item 1')
+        expect(result[1]!.content).toBe('Item 2')
+        expect(result[2]!.content).toBe('Item 3')
+      }
+    })
+
+    test('handles mixed array content with type guards', () => {
+      const line = JSON.stringify({
+        message: {
+          content: [
+            { type: 'tool_use', name: 'Valid' },
+            'string-item',
+            { no_type_property: true },
+            null,
+            { type: 'tool_use', name: 'AlsoValid' },
+          ],
+        },
+      })
+      const result = wildcardParser.parseLine(line)
+      expect(Array.isArray(result)).toBe(true)
+      if (Array.isArray(result)) {
+        expect(result).toHaveLength(2)
+        expect(result[0]!.title).toBe('Valid')
+        expect(result[1]!.title).toBe('AlsoValid')
+      }
+    })
+  })
+
+  describe('jsonPath with array wildcard', () => {
+    test('extracts array with [*] wildcard', () => {
+      const obj = { items: [{ id: 1 }, { id: 2 }] }
+      const result = jsonPath(obj, '$.items[*]')
+      expect(Array.isArray(result)).toBe(true)
+      if (Array.isArray(result)) {
+        expect(result).toHaveLength(2)
+      }
+    })
+
+    test('returns undefined for non-array at wildcard position', () => {
+      const obj = { items: 'not-an-array' }
+      const result = jsonPath(obj, '$.items[*]')
+      expect(result).toBeUndefined()
+    })
+
+    test('handles empty array', () => {
+      const obj = { items: [] }
+      const result = jsonPath(obj, '$.items[*]')
+      expect(result).toEqual([])
+    })
+
+    test('handles nested path to array', () => {
+      const obj = { message: { content: [1, 2, 3] } }
+      const result = jsonPath(obj, '$.message.content[*]')
+      expect(result).toEqual([1, 2, 3])
+    })
+
+    test('returns undefined when path before wildcard is invalid', () => {
+      const obj = { items: [1, 2, 3] }
+      const result = jsonPath(obj, '$.missing[*]')
+      expect(result).toBeUndefined()
+    })
+  })
+
   describe('parseResult', () => {
     test('detects result event', () => {
       const line = JSON.stringify({ type: 'result', result: 'Final answer' })


### PR DESCRIPTION
Adds support for JSONPath wildcard syntax `[*]` in outputEvents mappings to handle CLI agents that emit tool calls inside arrays (like Claude Code).

## Problem

Claude Code's `--output-format stream-json` emits events like:
```json
{
  "type": "assistant",
  "message": {
    "content": [
      {"type": "tool_use", "name": "WebSearch", "input": {...}},
      {"type": "tool_result", "tool_use_id": "...", "content": "..."}
    ]
  }
}
```

Tool calls are nested inside `$.message.content[]`, not at root level. The current parser can only check single JSONPath locations and cannot iterate over array items.

## Solution

### 1. Extended JSONPath Support

Added wildcard syntax `[*]` to `jsonPath()`:
- `$.message.content[*]` returns all items in the array
- Maintains backward compatibility with indexed access `[0]`, `[1]`, etc.

### 2. Array-aware Parser

Modified `parseLine()` to:
- Detect when `jsonPath()` returns an array (from wildcard)
- Iterate over array items and match each against the expected value
- Return multiple `ParsedUpdate` objects when multiple items match
- Preserve original behavior for non-array results

### 3. Session Manager Updates

Updated output collection in `headless-session-manager.ts`:
- Handle both single updates and arrays of updates
- Emit each update individually via `onUpdate` callback
- Collect all updates in the trajectory

## Usage

Schema authors can now use wildcard paths:

```json
{
  "outputEvents": [
    {
      "match": {"path": "$.message.content[*].type", "value": "tool_use"},
      "emitAs": "tool_call",
      "extract": {"title": "$.name", "status": "'pending'"}
    }
  ]
}
```

This will:
1. Extract `$.message.content[*]` → returns array of content items
2. Check each item's `.type` property
3. Emit a `tool_call` update for each item where `type === 'tool_use'`

## Testing

Verified with Claude Code CLI output containing tool calls nested in `message.content` arrays. Captured tool_use and tool_result events that were previously invisible in trajectories.

## Related

This enables proper trajectory capture for agents discovered during agentic web search playoffs evaluation: https://github.com/plaited/acp-evals (private repo)